### PR TITLE
Better Mech2d visualization of lift

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -33,6 +33,7 @@ public final class Constants {
   public static class CanIdentifiers {
     public static final String CTRECANBus = "CTRE bus";
 
+    // Swerve (30s & 40s)
     public static final int FLSpeedCANID = 30;
     public static final int FLAngleCANID = 31;
     public static final int FLAbsoEncoCANID = 32;
@@ -46,12 +47,25 @@ public final class Constants {
     public static final int BRAngleCANID = 37;
     public static final int BRAbsoEncoCANID = 38;
     public static final int GyroCANID = 45;
-    public static final int BasePivotMotorCANID = 46;
-    public static final int BasePivotCANcoderCANID = 47;
-    public static final int GripperPivotMotorCANID = 48;
-    public static final int GripperPivotCANCoderCANID = 49;
-    public static final int GripperMotorCANID = 50;
+
+    // Base Pivot (20s)
+    public static final int BasePivotMotorCANID = 20; // TODO: set on robot
+    public static final int BasePivotCANcoderCANID = 21; // TODO: set on robot
+
+    // Extender (50s)
     public static final int ExtenderMotorCANID = 51;
+
+    // Gripper Pivot (60s)
+    public static final int GripperPivotMotorCANID = 60; // TODO: set on robot
+    public static final int GripperPivotCANCoderCANID = 61; // TODO: set on robot
+
+    // Gripper (70s)
+    public static final int GripperCoralMotorCANID = 70; // TODO: set on robot
+    public static final int GripperAlgaeMotorCANID = 71; // TODO: set on robot
+
+    // Intake (80s)
+    public static final int IntakeMotor1CANID = 80; // TODO: set on robot
+    public static final int IntakeMotorBCANID = 81; // TODO: set on robot
   }
 
   /** This contains constants for all our IO ports on the RIO. */
@@ -130,7 +144,7 @@ public final class Constants {
     public static class BasePivotConstants {
       public static final Rotation2d MinAngle = Rotation2d.fromDegrees(30);
       public static final Rotation2d MaxAngle = Rotation2d.fromDegrees(90);
-      public static final Rotation2d StowAngle = Rotation2d.fromDegrees(40);
+      public static final Rotation2d StowAngle = Rotation2d.fromDegrees(80);
       public static final Rotation2d HandoffAngle = Rotation2d.fromDegrees(30);
       public static final Rotation2d ScoreL1Angle = Rotation2d.fromDegrees(54);
       public static final Rotation2d ScoreL2Angle = Rotation2d.fromDegrees(61);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -128,6 +128,7 @@ public class RobotContainer extends ChaosRobotContainer<SwerveDrive> {
     m_operator.x().whileTrue(new ChangeState().setLift(LiftState.SCORE_L2).setIntake(IntakeState.STOW));
     m_operator.b().whileTrue(new ChangeState().setLift(LiftState.SCORE_L3).setIntake(IntakeState.STOW));
     m_operator.y().whileTrue(new ChangeState().setLift(LiftState.SCORE_L4).setIntake(IntakeState.STOW));
+    m_operator.back().onTrue(new InstantCommand(() -> Gripper.hasCoralFrontGrippedSim = !Gripper.hasCoralFrontGrippedSim)); // TODO: delete if back button needed for competition
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -13,6 +13,7 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.system.plant.LinearSystemId;
 import edu.wpi.first.wpilibj.simulation.DCMotorSim;
+import frc.robot.Constants.CanIdentifiers;
 import frc.robot.Constants.IntakeConstants;
 import frc.robot.subsystems.shared.StateBasedSubsystem;
 import frc.robot.subsystems.shared.SubsystemState;
@@ -45,8 +46,8 @@ public class Intake extends StateBasedSubsystem<Intake.IntakeState> {
           m_pivotDcMotor,
           0.001,
           0.001);
-  private ChaosTalonFx m_pivotMotor1 = new ChaosTalonFx(10, m_gearRatio, m_pivotMotorSim, true);
-  private ChaosTalonFx m_pivotMotor2 = new ChaosTalonFx(11, m_gearRatio, m_pivotMotorSim, false);
+  private ChaosTalonFx m_pivotMotor1 = new ChaosTalonFx(CanIdentifiers.IntakeMotor1CANID, m_gearRatio, m_pivotMotorSim, true);
+  private ChaosTalonFx m_pivotMotor2 = new ChaosTalonFx(CanIdentifiers.IntakeMotorBCANID, m_gearRatio, m_pivotMotorSim, false);
   private PIDTuner m_pidTuner = new PIDTuner("IntakePivot", true, 0.1, 0.001, 0.0, this::tunePids);
 
   /** Creates a new Intake. */

--- a/src/main/java/frc/robot/subsystems/lift/Gripper.java
+++ b/src/main/java/frc/robot/subsystems/lift/Gripper.java
@@ -4,10 +4,7 @@
 
 package frc.robot.subsystems.lift;
 
-import edu.wpi.first.math.system.plant.DCMotor;
-import edu.wpi.first.math.system.plant.LinearSystemId;
 import edu.wpi.first.wpilibj.DigitalInput;
-import edu.wpi.first.wpilibj.simulation.DCMotorSim;
 import frc.robot.Constants.CanIdentifiers;
 import frc.robot.Constants.IoPortsConstants;
 import frc.robot.Robot;
@@ -17,22 +14,12 @@ import java.util.function.Supplier;
 
 /** Add your docs here. */
 public class Gripper extends AbstractLiftPart {
-  private double m_targetSpeed = 0;
-  private double m_gearRation = 40.0;
-  private double m_jkgMetersSquared = 0.1;
   public static boolean hasCoralFrontGrippedSim = false;
   public static boolean hasCoralBackGrippedSim = false;
   public static boolean hasAlgaeGrippedSim = false;
-  private DCMotor m_dcMotor = DCMotor.getKrakenX60(1);
-  private DCMotorSim m_motorSim =
-      new DCMotorSim(
-          LinearSystemId.createDCMotorSystem(m_dcMotor, m_jkgMetersSquared, m_gearRation),
-          m_dcMotor,
-          0.001,
-          0.001);
 
-  private ChaosTalonFx m_motor =
-      new ChaosTalonFx(CanIdentifiers.GripperMotorCANID, m_gearRation, m_motorSim, true);
+  private ChaosTalonFx m_coralMotor = new ChaosTalonFx(CanIdentifiers.GripperCoralMotorCANID);
+  private ChaosTalonFx m_algaeMotor = new ChaosTalonFx(CanIdentifiers.GripperAlgaeMotorCANID);
 
   private DigitalInput m_algaeSensor = new DigitalInput(IoPortsConstants.AlgaeChannelID);
   private DigitalInput m_coralSensor1 = new DigitalInput(IoPortsConstants.CoralOneChannelID);
@@ -47,12 +34,26 @@ public class Gripper extends AbstractLiftPart {
     super(idLiftValuesSupplier);
   }
 
-  public void setTargetSpeed(double newSpeed) {
-    m_targetSpeed = newSpeed;
+  /**
+   * Sets the speed [-1.0, 1.0] of the coral gripper.
+   */
+  public void setCoralGripSpeed(double newSpeed) {
+    m_coralMotor.set(newSpeed);
   }
 
-  public double getCurrentSpeed() {
-    return m_targetSpeed;
+  /**
+   * Sets the speed [-1.0, 1.0] of the algae gripper.
+   */
+  public void setAlgaeGripSpeed(double newSpeed) {
+    m_algaeMotor.set(newSpeed);
+  }
+
+  public double getCoralGripSpeed() {
+    return m_coralMotor.get();
+  }
+
+  public double getAlgaeGripSpeed() {
+    return m_algaeMotor.get();
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/lift/IdLift.java
+++ b/src/main/java/frc/robot/subsystems/lift/IdLift.java
@@ -22,10 +22,12 @@ public class IdLift extends StateBasedSubsystem<IdLift.LiftState> {
   public class IdLiftValues {
     public Rotation2d basePivotAngle;
     public Rotation2d gripperPivotAngle;
-    public double gripperSpeed;
+    public double coralGripSpeed;
+    public double algaeGripSpeed;
     public double extenderLength;
     public boolean isBasePivotAtSafeAngle;
     public boolean isExtenderAtSafeLength;
+    public boolean hasAlgaeGripped;
     public boolean hasCoralBackGripped;
     public boolean hasCoralFrontGripped;
   }
@@ -37,10 +39,12 @@ public class IdLift extends StateBasedSubsystem<IdLift.LiftState> {
     IdLiftValues values = new IdLiftValues();
     values.basePivotAngle = m_basePivot.getCurrentAngle();
     values.gripperPivotAngle = m_gripperPivot.getCurrentAngle();
-    values.gripperSpeed = m_gripper.getCurrentSpeed();
+    values.coralGripSpeed = m_gripper.getCoralGripSpeed();
+    values.algaeGripSpeed = m_gripper.getAlgaeGripSpeed();
     values.extenderLength = m_extender.getCurrentLength();
     values.isBasePivotAtSafeAngle = m_basePivot.isSafeAngle();
     values.isExtenderAtSafeLength = m_extender.isSafeLength();
+    values.hasAlgaeGripped = m_gripper.hasAlgae();
     values.hasCoralBackGripped = m_gripper.hasCoralBack();
     values.hasCoralFrontGripped = m_gripper.hasCoralFront();
     return values;
@@ -121,7 +125,7 @@ public class IdLift extends StateBasedSubsystem<IdLift.LiftState> {
 
   private void manualState() {
     m_basePivot.setSpeed(0.0);
-    m_gripper.setTargetSpeed(0.0);
+    m_gripper.setCoralGripSpeed(0.0);
     m_gripperPivot.setSpeed(0.0);
     m_extender.setSpeed(m_operator.getRightY() * 0.3);
   }
@@ -130,14 +134,14 @@ public class IdLift extends StateBasedSubsystem<IdLift.LiftState> {
     m_basePivot.setTargetAngle(BasePivotConstants.StowAngle);
     m_extender.setTargetLength(ExtenderConstants.StowLengthMeter);
     m_gripperPivot.setTargetAngle(GripperPivotConstants.StowAngle);
-    m_gripper.setTargetSpeed(0.0);
+    m_gripper.setCoralGripSpeed(0.0);
   }
 
   private void intakeFromFloorState() {
     m_basePivot.setTargetAngle(BasePivotConstants.HandoffAngle);
     m_extender.setTargetLength(ExtenderConstants.HandoffLengthMeter);
     m_gripperPivot.setTargetAngle(GripperPivotConstants.HandoffAngle);
-    m_gripper.setTargetSpeed(0.5);
+    m_gripper.setCoralGripSpeed(0.5);
   }
 
   private void intakeFromHpState() {
@@ -148,7 +152,7 @@ public class IdLift extends StateBasedSubsystem<IdLift.LiftState> {
     m_basePivot.setTargetAngle(BasePivotConstants.hpIntakeAngle);
     m_extender.setTargetLength(ExtenderConstants.hpIntakeLengthMeter);
     m_gripperPivot.setTargetAngle(GripperPivotConstants.hpIntakeAngle);
-    m_gripper.setTargetSpeed(-0.5);
+    m_gripper.setCoralGripSpeed(-0.5);
   }
 
   private void scoreL1State() {
@@ -160,9 +164,9 @@ public class IdLift extends StateBasedSubsystem<IdLift.LiftState> {
     m_extender.setTargetLength(ExtenderConstants.ScoreL1LengthMeter);
     m_gripperPivot.setTargetAngle(GripperPivotConstants.ScoreL1Angle);
     if (isPoseReady()) {
-      m_gripper.setTargetSpeed(0.5);
+      m_gripper.setCoralGripSpeed(0.5);
     } else {
-      m_gripper.setTargetSpeed(0);
+      m_gripper.setCoralGripSpeed(0);
     }
   }
 
@@ -175,9 +179,9 @@ public class IdLift extends StateBasedSubsystem<IdLift.LiftState> {
     m_extender.setTargetLength(ExtenderConstants.ScoreL2LengthMeter);
     m_gripperPivot.setTargetAngle(GripperPivotConstants.ScoreL2Angle);
     if (isPoseReady()) {
-      m_gripper.setTargetSpeed(0.5);
+      m_gripper.setCoralGripSpeed(0.5);
     } else {
-      m_gripper.setTargetSpeed(0);
+      m_gripper.setCoralGripSpeed(0);
     }
   }
 
@@ -190,9 +194,9 @@ public class IdLift extends StateBasedSubsystem<IdLift.LiftState> {
     m_extender.setTargetLength(ExtenderConstants.ScoreL3LengthMeter);
     m_gripperPivot.setTargetAngle(GripperPivotConstants.ScoreL3Angle);
     if (isPoseReady()) {
-      m_gripper.setTargetSpeed(0.5);
+      m_gripper.setCoralGripSpeed(0.5);
     } else {
-      m_gripper.setTargetSpeed(0);
+      m_gripper.setCoralGripSpeed(0);
     }
   }
 
@@ -205,9 +209,9 @@ public class IdLift extends StateBasedSubsystem<IdLift.LiftState> {
     m_extender.setTargetLength(ExtenderConstants.ScoreL4LengthMeter);
     m_gripperPivot.setTargetAngle(GripperPivotConstants.ScoreL4Angle);
     if (isPoseReady()) {
-      m_gripper.setTargetSpeed(-0.5);
+      m_gripper.setCoralGripSpeed(-0.5);
     } else {
-      m_gripper.setTargetSpeed(0);
+      m_gripper.setCoralGripSpeed(0);
     }
   }
 }


### PR DESCRIPTION
This adds better support for the Mech2d visualization:
* gripper pivot is offset from the actual extender
* coral shows up or hides based on sensors
* algae shows up or hides based on sensors
* separate ligament below coral spots for showing motor direction

Also some cleanup:
* organized CAN IDs into separate ranges to make it easier to organize and add can devices
* added the motors to gripper for coral AND algae
* added ability to create ChaosTalonFx without motor sim models (for cases like gripping where we don't really care right now)