### PR TITLE
TalonFx Tunables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    implementation 'com.chaos131:shared:2025.0.9'
+    implementation 'com.chaos131:shared:2025.0.10'
 }
 
 test {

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -168,6 +168,31 @@ public final class Constants {
     public static class ExtenderConstants {
       public static final double MinLengthMeter = 0.1;
       public static final double MaxLengthMeter = 1.6;
+
+      // Slot 0 Configs // TODO: get real values
+      public static final double kP = 1.0;
+      public static final double kI = 0.0;
+      public static final double kD = 0.0;
+      public static final double kG = 0.0;
+      public static final double kS = 0.25;
+      public static final double kV = 0.12;
+      public static final double kA = 0.01;
+
+      // Motion Magic // TODO: get real values
+      public static final double MMCruiseVelocity = 80;
+      public static final double MMAcceleration = 160;
+      public static final double MMJerk = 1600;
+
+      // Current limits // TODO: get real values
+      public static final double SupplyCurrentLimit = 40;
+      public static final double StatorCurrentLimit = 40;
+
+      // Sensor Feedback // TODO: get real values
+      public static final double RotorToSensorRatio = 1.0;
+      public static final double SensorToMechanismRatio = 1.0;
+
+      // Ramp Rates // TODO: get real values
+      public static final double VoltageClosedLoopRampPeriod = 0.1;
     }
 
     /** This contains constants for our Gripper. */

--- a/src/main/java/frc/robot/utils/ChaosTalonFx.java
+++ b/src/main/java/frc/robot/utils/ChaosTalonFx.java
@@ -104,6 +104,8 @@ public class ChaosTalonFx extends TalonFX {
 
   /**
    * Tunes the PID default slot (0) PID of the motor.
+   *
+   * @deprecated this will be removed in favor of ChaosTalonFxTuner
    */
   public void tunePid(PIDFValue pidValue, double kg) {
     var slot0 = new Slot0Configs();
@@ -117,6 +119,8 @@ public class ChaosTalonFx extends TalonFX {
 
   /**
    * Tunes the PID & MotionMagic default slot (0).
+   *
+   * @deprecated this will be removed in favor of ChaosTalonFxTuner
    */
   public void tuneMotionMagic(PIDFValue pidValue, double kg, double ks, double kv, double ka) {
     var slot0 = new Slot0Configs();

--- a/src/main/java/frc/robot/utils/ChaosTalonFxTuner.java
+++ b/src/main/java/frc/robot/utils/ChaosTalonFxTuner.java
@@ -1,0 +1,43 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.utils;
+
+import com.chaos131.util.DashboardNumber;
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import java.util.function.BiConsumer;
+
+/** This creates a class to easily tune TalonFXConfigs for 1 or more motors. */
+public class ChaosTalonFxTuner {
+  private String m_name;
+  private ChaosTalonFx[] m_talons;
+
+  /**
+   * Creates a tuner for modifying numeric values of TalonFxConfigs.
+   *
+   * @param name the name of the motor tuner
+   * @param talons the list of talons to tune
+   */
+  public ChaosTalonFxTuner(String name, ChaosTalonFx... talons) {
+    m_name = name;
+    m_talons = talons;
+  }
+
+  /**
+   * Creates a tunable value for the TalonFxConfiguration and will apply/burn the value to the motor when it changes.
+   *
+   * @param valueName the name of the value (e.g., "SupplyCurrentLimit")
+   * @param initialValue the value to start at (is not applied by default)
+   * @param onUpdate the function to update the configuration
+   * @return the Dashboard number
+   */
+  public DashboardNumber tunable(String valueName, double initialValue, BiConsumer<TalonFXConfiguration, Double> onUpdate) {
+    return new DashboardNumber("TalonFxConfig/" + m_name + "/" + valueName, initialValue, true, false, newValue -> {
+      for (ChaosTalonFx chaosTalonFx : m_talons) {
+        onUpdate.accept(chaosTalonFx.Configuration, newValue);
+        chaosTalonFx.applyConfig();
+      }
+    });
+  }
+}


### PR DESCRIPTION
This will allow us to easily tune our TalonFXs from the dashboard (Elastic's table editing is super convenient for this). 

![image](https://github.com/user-attachments/assets/2174677b-3b79-43be-93e8-896669392441)

I've done the extender and if we like/merge this, the students can do the other lift parts. 

I hope this is an appropriate level of abstraction - the logic and values for each part still lives in each part - The `ChaosTalonFxTuner` just gives a shortcut for creating the dashboard values and updating and applying the config after a change. 

And I think we want all these values defined in Constants, but how does everyone else feel?