### PR TITLE
Week1/minor fixes

### DIFF
--- a/src/main/java/frc/robot/SimConstants.java
+++ b/src/main/java/frc/robot/SimConstants.java
@@ -1,0 +1,38 @@
+package frc.robot;
+
+/**
+ * This class holds all of our 2025 constants that are overrides for simulation.
+ */
+public final class SimConstants {
+
+  /** This contains sim constants for our Base Pivot. */
+  public static class SimBasePivotConstants {
+
+    public static final double kP = 400.0;
+    public static final double kI = 10.00;
+    public static final double kD = 0.0;
+    
+    public static final double canCoderOffsetDegrees = 90;
+  }
+
+  /** This contains sim constants for our Gripper Pivot. */
+  public static class SimGripperPivotConstants {
+
+    public static final double kP = 10.0;
+    public static final double kI = 0.0;
+    public static final double kD = 0.0;
+
+    public static final double canCoderOffsetDegrees = 0;
+  }
+
+  /** This contains sim constants for our Extender. */
+  public static class SimExtenderConstants {
+
+    // Slot 0 Configs
+    public static final double kP = 20.0;
+    public static final double kI = 1.0;
+    public static final double kD = 5.0;
+
+  }
+
+}

--- a/src/main/java/frc/robot/subsystems/lift/BasePivot.java
+++ b/src/main/java/frc/robot/subsystems/lift/BasePivot.java
@@ -18,6 +18,8 @@ import edu.wpi.first.math.system.plant.LinearSystemId;
 import edu.wpi.first.wpilibj.simulation.DCMotorSim;
 import frc.robot.Constants.CanIdentifiers;
 import frc.robot.Constants.MidLiftConstants.BasePivotConstants;
+import frc.robot.Robot;
+import frc.robot.SimConstants.SimBasePivotConstants;
 import frc.robot.subsystems.lift.IdLift.IdLiftValues;
 import frc.robot.utils.ChaosCanCoder;
 import frc.robot.utils.ChaosCanCoderTuner;
@@ -45,12 +47,12 @@ public class BasePivot extends AbstractLiftPart {
   private ChaosCanCoderTuner m_canCoderTuner = new ChaosCanCoderTuner("Base Pivot", m_canCoder);
 
   private DashboardNumber m_canCoderOffsetDegrees = m_canCoderTuner.tunable("CANCoder Tuner",
-      BasePivotConstants.canCoderOffsetDegrees, (config, newValue) -> 
+      Robot.isReal() ? BasePivotConstants.canCoderOffsetDegrees : SimBasePivotConstants.canCoderOffsetDegrees, (config, newValue) -> 
       config.MagnetSensor.MagnetOffset = Rotation2d.fromDegrees(newValue).getRotations());
 
-  private DashboardNumber m_kp = m_talonTuner.tunable("kP", BasePivotConstants.kP, (config, newValue) -> config.Slot0.kP = newValue);
-  private DashboardNumber m_ki = m_talonTuner.tunable("kI", BasePivotConstants.kI, (config, newValue) -> config.Slot0.kI = newValue);
-  private DashboardNumber m_kd = m_talonTuner.tunable("kD", BasePivotConstants.kD, (config, newValue) -> config.Slot0.kD = newValue);
+  private DashboardNumber m_kp = m_talonTuner.tunable("kP", Robot.isReal() ? BasePivotConstants.kP : SimBasePivotConstants.kP, (config, newValue) -> config.Slot0.kP = newValue);
+  private DashboardNumber m_ki = m_talonTuner.tunable("kI", Robot.isReal() ? BasePivotConstants.kI : SimBasePivotConstants.kI, (config, newValue) -> config.Slot0.kI = newValue);
+  private DashboardNumber m_kd = m_talonTuner.tunable("kD", Robot.isReal() ? BasePivotConstants.kD : SimBasePivotConstants.kD, (config, newValue) -> config.Slot0.kD = newValue);
   private DashboardNumber m_kg = m_talonTuner.tunable("kG", BasePivotConstants.kG, (config, newValue) -> config.Slot0.kG = newValue);
   private DashboardNumber m_ks = m_talonTuner.tunable("kS", BasePivotConstants.kS, (config, newValue) -> config.Slot0.kS = newValue);
   private DashboardNumber m_kv = m_talonTuner.tunable("kV", BasePivotConstants.kV, (config, newValue) -> config.Slot0.kV = newValue);

--- a/src/main/java/frc/robot/subsystems/lift/Extender.java
+++ b/src/main/java/frc/robot/subsystems/lift/Extender.java
@@ -19,6 +19,7 @@ import frc.robot.Constants.CanIdentifiers;
 import frc.robot.Constants.IoPortsConstants;
 import frc.robot.Constants.MidLiftConstants.ExtenderConstants;
 import frc.robot.Robot;
+import frc.robot.SimConstants.SimExtenderConstants;
 import frc.robot.subsystems.lift.IdLift.IdLiftValues;
 import frc.robot.utils.ChaosTalonFx;
 import frc.robot.utils.ChaosTalonFxTuner;
@@ -39,14 +40,13 @@ public class Extender extends AbstractLiftPart {
           0.001,
           0.001);
   private ChaosTalonFx m_motor1 = new ChaosTalonFx(CanIdentifiers.ExtenderMotorCANID);
-
   private ChaosTalonFxTuner m_tuner = new ChaosTalonFxTuner("Extender", m_motor1);
   private DigitalInput m_minimumSensor = new DigitalInput(IoPortsConstants.ExtenderMinimumChannelID);
 
   // Motion Magic Slot 0 Configs
-  private DashboardNumber m_kp = m_tuner.tunable("kP", ExtenderConstants.kP, (config, newValue) -> config.Slot0.kP = newValue);
-  private DashboardNumber m_ki = m_tuner.tunable("kI", ExtenderConstants.kI, (config, newValue) -> config.Slot0.kI = newValue);
-  private DashboardNumber m_kd = m_tuner.tunable("kD", ExtenderConstants.kD, (config, newValue) -> config.Slot0.kD = newValue);
+  private DashboardNumber m_kp = m_tuner.tunable("kP", Robot.isReal() ? ExtenderConstants.kP : SimExtenderConstants.kP, (config, newValue) -> config.Slot0.kP = newValue);
+  private DashboardNumber m_ki = m_tuner.tunable("kI", Robot.isReal() ? ExtenderConstants.kI : SimExtenderConstants.kI, (config, newValue) -> config.Slot0.kI = newValue);
+  private DashboardNumber m_kd = m_tuner.tunable("kD", Robot.isReal() ? ExtenderConstants.kD : SimExtenderConstants.kD, (config, newValue) -> config.Slot0.kD = newValue);
   private DashboardNumber m_kg = m_tuner.tunable("kG", ExtenderConstants.kG, (config, newValue) -> config.Slot0.kG = newValue);
   private DashboardNumber m_ks = m_tuner.tunable("kS", ExtenderConstants.kS, (config, newValue) -> config.Slot0.kS = newValue);
   private DashboardNumber m_kv = m_tuner.tunable("kV", ExtenderConstants.kV, (config, newValue) -> config.Slot0.kV = newValue);

--- a/src/main/java/frc/robot/subsystems/lift/GripperPivot.java
+++ b/src/main/java/frc/robot/subsystems/lift/GripperPivot.java
@@ -20,6 +20,8 @@ import edu.wpi.first.wpilibj.simulation.DCMotorSim;
 import frc.robot.Constants.CanIdentifiers;
 import frc.robot.Constants.MidLiftConstants.GripperPivotConstants;
 import frc.robot.Constants.MidLiftConstants.LiftPoses;
+import frc.robot.SimConstants.SimGripperPivotConstants;
+import frc.robot.Robot;
 import frc.robot.subsystems.lift.IdLift.IdLiftValues;
 import frc.robot.utils.ChaosCanCoder;
 import frc.robot.utils.ChaosCanCoderTuner;
@@ -51,13 +53,13 @@ public class GripperPivot extends AbstractLiftPart {
   private ChaosCanCoderTuner m_canCoderTuner = new ChaosCanCoderTuner("Gripper Pivot", m_canCoder);
 
   private DashboardNumber m_canCoderOffsetDegrees = m_canCoderTuner.tunable("CANCoder Tuner",
-      GripperPivotConstants.canCoderOffsetDegrees, (config, newValue) -> 
+      Robot.isReal() ? GripperPivotConstants.canCoderOffsetDegrees : SimGripperPivotConstants.canCoderOffsetDegrees, (config, newValue) -> 
       config.MagnetSensor.MagnetOffset = Rotation2d.fromDegrees(newValue).getRotations());
 
   // Motion Magic Slot 0 Configs
-  private DashboardNumber m_kp = m_tuner.tunable("kP", GripperPivotConstants.kP, (config, newValue) -> config.Slot0.kP = newValue);
-  private DashboardNumber m_ki = m_tuner.tunable("kI", GripperPivotConstants.kI, (config, newValue) -> config.Slot0.kI = newValue);
-  private DashboardNumber m_kd = m_tuner.tunable("kD", GripperPivotConstants.kD, (config, newValue) -> config.Slot0.kD = newValue);
+  private DashboardNumber m_kp = m_tuner.tunable("kP", Robot.isReal() ? GripperPivotConstants.kP : SimGripperPivotConstants.kP, (config, newValue) -> config.Slot0.kP = newValue);
+  private DashboardNumber m_ki = m_tuner.tunable("kI", Robot.isReal() ? GripperPivotConstants.kI : SimGripperPivotConstants.kI, (config, newValue) -> config.Slot0.kI = newValue);
+  private DashboardNumber m_kd = m_tuner.tunable("kD", Robot.isReal() ? GripperPivotConstants.kD : SimGripperPivotConstants.kD, (config, newValue) -> config.Slot0.kD = newValue);
   private DashboardNumber m_kg = m_tuner.tunable("kG", GripperPivotConstants.kG, (config, newValue) -> config.Slot0.kG = newValue);
   private DashboardNumber m_ks = m_tuner.tunable("kS", GripperPivotConstants.kS, (config, newValue) -> config.Slot0.kS = newValue);
   private DashboardNumber m_kv = m_tuner.tunable("kV", GripperPivotConstants.kV, (config, newValue) -> config.Slot0.kV = newValue);


### PR DESCRIPTION
This just does some minor fixes so we can focus on real robot logic tomorrow:

* Helps protect against autos if a student accidentally tells PathPlanner to Reset Odometry
  *  We can ignore the reset odometry call if we have seen camera updates
* Allows some sim values to update real values to achieve the following:
  * More realistic starting positions for the pivots
  * more realistic motion of the mechanism (less wild swinging)