### PR TITLE
Gripper changes

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -301,6 +301,8 @@ public final class Constants {
       public static final double AlgaeDropDebounceSeconds = 0.5;
       public static final Current AlgaeStatorCurrentLimit = Amps.of(15);
       public static final Current AlgaeSupplyCurrentLimit = Amps.of(15);
+      public static final Current CoralStatorCurrentLimit = Amps.of(15);
+      public static final Current CoralSupplyCurrentLimit = Amps.of(15);
       public static final double IntakeAlgaeSpeed = -0.5;
       public static final double HoldAlgaeSpeed = -0.2;
       public static final double OutakeAlgaeSpeed = 0.5;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -308,9 +308,11 @@ public final class Constants {
       public static final double OutakeAlgaeSpeed = 0.5;
       public static final double IntakeCoralOnAlgaeMotorSpeed = 0.5;
       public static final double OutakeCoralOnAlgaeMotorSpeed = -0.5;
+      public static final double OutakeInvertedCoralOnAlgaeMotorSpeed = 0.5;
       public static final double IntakeCoralSpeed = -0.5;
       public static final double IntakeCoralSlow = -0.2;
       public static final double OutakeCoralSpeed = 0.5;
+      public static final double OutakeInvertedCoralSpeed = -0.5;
     }
   }
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -304,6 +304,8 @@ public final class Constants {
       public static final double IntakeAlgaeSpeed = -0.5;
       public static final double HoldAlgaeSpeed = -0.2;
       public static final double OutakeAlgaeSpeed = 0.5;
+      public static final double IntakeCoralOnAlgaeMotorSpeed = 0.5;
+      public static final double OutakeCoralOnAlgaeMotorSpeed = -0.5;
       public static final double IntakeCoralSpeed = -0.5;
       public static final double IntakeCoralSlow = -0.2;
       public static final double OutakeCoralSpeed = 0.5;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -302,6 +302,7 @@ public final class Constants {
       public static final Current AlgaeStatorCurrentLimit = Amps.of(15);
       public static final Current AlgaeSupplyCurrentLimit = Amps.of(15);
       public static final double IntakeAlgaeSpeed = -0.5;
+      public static final double HoldAlgaeSpeed = -0.2;
       public static final double OutakeAlgaeSpeed = 0.5;
       public static final double IntakeCoralSpeed = -0.5;
       public static final double IntakeCoralSlow = -0.2;

--- a/src/main/java/frc/robot/subsystems/arm/Arm.java
+++ b/src/main/java/frc/robot/subsystems/arm/Arm.java
@@ -238,6 +238,7 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
     m_extender.setTargetLength(ArmPoses.Stow.getExtensionMeters());
     m_gripperPivot.setTargetAngle(ArmPoses.Stow.getGripperPivotAngle());
     m_gripper.setCoralGripSpeed(0.0);
+    m_gripper.setAlgaeGripSpeed(0.0);
   }
 
   private void intakeCoralFromFloorState() {
@@ -328,12 +329,14 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
     m_basePivot.setTargetAngle(ArmPoses.ScoreProcessor.getBasePivotAngle());
     m_extender.setTargetLength(ArmPoses.ScoreProcessor.getExtensionMeters());
     m_gripperPivot.setTargetAngle(ArmPoses.ScoreProcessor.getGripperPivotAngle());
+    m_gripper.setAlgaeGripSpeed(GripperConstants.HoldAlgaeSpeed);
   }
 
   private void prepBargeState() {
     m_basePivot.setTargetAngle(ArmPoses.ScoreBarge.getBasePivotAngle());
     m_extender.setTargetLength(ArmPoses.ScoreBarge.getExtensionMeters());
     m_gripperPivot.setTargetAngle(ArmPoses.ScoreBarge.getGripperPivotAngle());
+    m_gripper.setAlgaeGripSpeed(GripperConstants.HoldAlgaeSpeed);
   }
 
   private void scoreL1State() {
@@ -395,6 +398,7 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
     m_basePivot.setTargetAngle(ArmPoses.HoldAlgae.getBasePivotAngle());
     m_extender.setTargetLength(ArmPoses.HoldAlgae.getExtensionMeters());
     m_gripperPivot.setTargetAngle(ArmPoses.HoldAlgae.getGripperPivotAngle());
+    m_gripper.setAlgaeGripSpeed(GripperConstants.HoldAlgaeSpeed);
     if (!m_gripper.hasAlgae()) {
       changeState(ArmState.STOW);
       return;

--- a/src/main/java/frc/robot/subsystems/arm/Arm.java
+++ b/src/main/java/frc/robot/subsystems/arm/Arm.java
@@ -250,11 +250,15 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
 
     if (!m_gripper.hasCoralFront()) {
       m_gripper.setCoralGripSpeed(GripperConstants.IntakeCoralSpeed); 
+      m_gripper.setAlgaeGripSpeed(GripperConstants.IntakeCoralOnAlgaeMotorSpeed);
     } else if (m_gripper.hasCoralFront() && !m_gripper.hasCoralBack()) {
       m_gripper.setCoralGripSpeed(GripperConstants.IntakeCoralSlow);
+      m_gripper.setAlgaeGripSpeed(0.0);
     } else {
       m_gripper.setCoralGripSpeed(0.0);
+      m_gripper.setAlgaeGripSpeed(0.0);
       changeState(ArmState.HOLD_CORAL);
+      return;
     }
 
     m_basePivot.setTargetAngle(ArmPoses.FloorIntakeCoral.getBasePivotAngle());
@@ -272,11 +276,13 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
     } else {
       m_gripper.setAlgaeGripSpeed(0.0);
       changeState(ArmState.HOLD_ALGAE);
+      return;
     }
 
     m_basePivot.setTargetAngle(ArmPoses.FloorIntakeAlgae.getBasePivotAngle());
     m_extender.setTargetLength(ArmPoses.FloorIntakeAlgae.getExtensionMeters());
     m_gripperPivot.setTargetAngle(ArmPoses.FloorIntakeAlgae.getGripperPivotAngle());
+    m_gripper.setCoralGripSpeed(0.0);
 
     if (Robot.isSimulation() && getElapsedStateSeconds() > 2.0) {
       Gripper.hasAlgaeGrippedSim = true;
@@ -292,9 +298,12 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
 
     if (!m_gripper.hasCoralFront()) {
       m_gripper.setCoralGripSpeed(GripperConstants.IntakeCoralSpeed); 
+      m_gripper.setAlgaeGripSpeed(GripperConstants.IntakeCoralOnAlgaeMotorSpeed);
     } else if (m_gripper.hasCoralFront() && !m_gripper.hasCoralBack()) {
       m_gripper.setCoralGripSpeed(GripperConstants.IntakeCoralSlow);
+      m_gripper.setAlgaeGripSpeed(0.0);
     } else {
+      m_gripper.setCoralGripSpeed(0.0);
       m_gripper.setCoralGripSpeed(0.0);
       changeState(ArmState.HOLD_CORAL);
       return;
@@ -330,6 +339,7 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
     m_extender.setTargetLength(ArmPoses.ScoreProcessor.getExtensionMeters());
     m_gripperPivot.setTargetAngle(ArmPoses.ScoreProcessor.getGripperPivotAngle());
     m_gripper.setAlgaeGripSpeed(GripperConstants.HoldAlgaeSpeed);
+    m_gripper.setCoralGripSpeed(0.0);
   }
 
   private void prepBargeState() {
@@ -337,6 +347,7 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
     m_extender.setTargetLength(ArmPoses.ScoreBarge.getExtensionMeters());
     m_gripperPivot.setTargetAngle(ArmPoses.ScoreBarge.getGripperPivotAngle());
     m_gripper.setAlgaeGripSpeed(GripperConstants.HoldAlgaeSpeed);
+    m_gripper.setCoralGripSpeed(0.0);
   }
 
   private void scoreL1State() {
@@ -357,6 +368,7 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
 
   private void scoreAlgaeState() {
     m_gripper.setAlgaeGripSpeed(GripperConstants.OutakeAlgaeSpeed);
+    m_gripper.setCoralGripSpeed(0.0);
     if (Robot.isSimulation() && getElapsedStateSeconds() > 2.0) {
       Gripper.hasAlgaeGrippedSim = false;
     }
@@ -368,8 +380,10 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
       m_extender.setTargetLength(ArmPoses.AlgaeHigh.getExtensionMeters());
       m_gripperPivot.setTargetAngle(ArmPoses.AlgaeHigh.getGripperPivotAngle());
       m_gripper.setAlgaeGripSpeed(GripperConstants.IntakeAlgaeSpeed);
+      m_gripper.setCoralGripSpeed(0.0);
     } else {
       changeState(ArmState.HOLD_CORAL);
+      return;
     }
   }
 
@@ -379,8 +393,10 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
       m_extender.setTargetLength(ArmPoses.AlgaeLow.getExtensionMeters());
       m_gripperPivot.setTargetAngle(ArmPoses.AlgaeLow.getGripperPivotAngle());
       m_gripper.setAlgaeGripSpeed(GripperConstants.IntakeAlgaeSpeed);
+      m_gripper.setCoralGripSpeed(0.0);
     } else {
       changeState(ArmState.HOLD_CORAL);
+      return;
     }
   }
 
@@ -388,6 +404,7 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
     m_basePivot.setTargetAngle(ArmPoses.HoldCoral.getBasePivotAngle());
     m_extender.setTargetLength(ArmPoses.HoldCoral.getExtensionMeters());
     m_gripperPivot.setTargetAngle(ArmPoses.HoldCoral.getGripperPivotAngle());
+    m_gripper.setAlgaeGripSpeed(0.0);
     if (!m_gripper.hasCoral()) {
       changeState(ArmState.STOW);
       return;
@@ -399,6 +416,7 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
     m_extender.setTargetLength(ArmPoses.HoldAlgae.getExtensionMeters());
     m_gripperPivot.setTargetAngle(ArmPoses.HoldAlgae.getGripperPivotAngle());
     m_gripper.setAlgaeGripSpeed(GripperConstants.HoldAlgaeSpeed);
+    m_gripper.setCoralGripSpeed(0.0);
     if (!m_gripper.hasAlgae()) {
       changeState(ArmState.STOW);
       return;
@@ -415,8 +433,10 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
     m_gripperPivot.setTargetAngle(armPose.getGripperPivotAngle());
     if ((!isPrep && isPoseReady()) || m_operator.rightBumper().getAsBoolean() || (DriverStation.isAutonomousEnabled() && isPoseClose() && m_stateTimer.hasElapsed(2))) {
       m_gripper.setCoralGripSpeed(GripperConstants.OutakeCoralSpeed);
+      m_gripper.setAlgaeGripSpeed(GripperConstants.OutakeCoralOnAlgaeMotorSpeed);
     } else {
       m_gripper.setCoralGripSpeed(0);
+      m_gripper.setAlgaeGripSpeed(0.0);
     }
 
     if (!isPrep && Robot.isSimulation() && getElapsedStateSeconds() > 2.0) {

--- a/src/main/java/frc/robot/subsystems/arm/Arm.java
+++ b/src/main/java/frc/robot/subsystems/arm/Arm.java
@@ -317,21 +317,22 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
       Gripper.hasCoralGrippedSim = true;
     }
   }
-
+  
+  //👻👽😺
   private void prepL1State() {
-    scoreHelperCoral(ArmPoses.ScoreL1, true);
+    scoreHelperCoral(ArmPoses.ScoreL1, true, false);
   }
 
   private void prepL2State() {
-    scoreHelperCoral(ArmPoses.ScoreL2, true);
+    scoreHelperCoral(ArmPoses.ScoreL2, true, false);
   }
 
   private void prepL3State() {
-    scoreHelperCoral(ArmPoses.ScoreL3, true);
+    scoreHelperCoral(ArmPoses.ScoreL3, true, false);
   }
 
   private void prepL4State() {
-    scoreHelperCoral(ArmPoses.ScoreL4, true);
+    scoreHelperCoral(ArmPoses.ScoreL4, true, true);
   }
 
   private void prepProcessorState() {
@@ -351,19 +352,19 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
   }
 
   private void scoreL1State() {
-    scoreHelperCoral(ArmPoses.ScoreL1, false);
+    scoreHelperCoral(ArmPoses.ScoreL1, false, false);
   }
 
   private void scoreL2State() {
-    scoreHelperCoral(ArmPoses.ScoreL2, false);
+    scoreHelperCoral(ArmPoses.ScoreL2, false, false);
   }
 
   private void scoreL3State() {
-    scoreHelperCoral(ArmPoses.ScoreL3, false);
+    scoreHelperCoral(ArmPoses.ScoreL3, false, false);
   }
 
   private void scoreL4State() {
-    scoreHelperCoral(ArmPoses.ScoreL4, false);
+    scoreHelperCoral(ArmPoses.ScoreL4, false, true);
   }
 
   private void scoreAlgaeState() {
@@ -423,7 +424,7 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
     }
   }
 
-  private void scoreHelperCoral(ArmPose armPose, boolean isPrep) {
+  private void scoreHelperCoral(ArmPose armPose, boolean isPrep, boolean isScoringInverted) {
     if (!(m_gripper.hasCoral())) {
       changeState(ArmState.STOW);
       return;
@@ -432,8 +433,8 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
     m_extender.setTargetLength(armPose.getExtensionMeters());
     m_gripperPivot.setTargetAngle(armPose.getGripperPivotAngle());
     if ((!isPrep && isPoseReady()) || m_operator.rightBumper().getAsBoolean() || (DriverStation.isAutonomousEnabled() && isPoseClose() && m_stateTimer.hasElapsed(2))) {
-      m_gripper.setCoralGripSpeed(GripperConstants.OutakeCoralSpeed);
-      m_gripper.setAlgaeGripSpeed(GripperConstants.OutakeCoralOnAlgaeMotorSpeed);
+      m_gripper.setCoralGripSpeed(isScoringInverted ? GripperConstants.OutakeInvertedCoralSpeed : GripperConstants.OutakeCoralSpeed);
+      m_gripper.setAlgaeGripSpeed(isScoringInverted ? GripperConstants.OutakeInvertedCoralOnAlgaeMotorSpeed : GripperConstants.OutakeCoralOnAlgaeMotorSpeed);
     } else {
       m_gripper.setCoralGripSpeed(0);
       m_gripper.setAlgaeGripSpeed(0.0);

--- a/src/main/java/frc/robot/subsystems/arm/Gripper.java
+++ b/src/main/java/frc/robot/subsystems/arm/Gripper.java
@@ -7,6 +7,7 @@ package frc.robot.subsystems.arm;
 import static edu.wpi.first.units.Units.Amps;
 
 import com.chaos131.util.DashboardNumber;
+import com.ctre.phoenix6.signals.NeutralModeValue;
 import edu.wpi.first.math.filter.Debouncer;
 import edu.wpi.first.math.filter.Debouncer.DebounceType;
 import edu.wpi.first.wpilibj.DigitalInput;
@@ -45,17 +46,26 @@ public class Gripper extends AbstractArmPart {
 
   private Debouncer m_coralSensorDebouncerBack = new Debouncer(GripperConstants.CoralDropDebounceSeconds, DebounceType.kFalling);
 
+  private ChaosTalonFxTuner m_coralTuner = new ChaosTalonFxTuner("CoralGripper", m_coralMotor);
+
   private ChaosTalonFx m_algaeMotor = new ChaosTalonFx(CanIdentifiers.GripperAlgaeMotorCANID);
 
   private Debouncer m_algaeSensorDebouncer = new Debouncer(GripperConstants.AlgaeDropDebounceSeconds, DebounceType.kFalling);
 
   private ChaosTalonFxTuner m_algaeTuner = new ChaosTalonFxTuner("AlgaeGripper", m_algaeMotor);
 
+
   // Current limits
   private DashboardNumber m_algaeSupplyCurrentLimit = m_algaeTuner.tunable(
       "SupplyCurrentLimit", GripperConstants.AlgaeSupplyCurrentLimit.in(Amps), (config, newValue) -> config.CurrentLimits.SupplyCurrentLimit = newValue);
   private DashboardNumber m_algaeStatorCurrentLimit = m_algaeTuner.tunable(
       "StatorCurrentLimit", GripperConstants.AlgaeStatorCurrentLimit.in(Amps), (config, newValue) -> config.CurrentLimits.StatorCurrentLimit = newValue);
+
+  private DashboardNumber m_coralSupplyCurrentLimit = m_coralTuner.tunable(
+      "SupplyCurrentLimit", GripperConstants.CoralStatorCurrentLimit.in(Amps), (config, newValue) -> config.CurrentLimits.SupplyCurrentLimit = newValue);
+  private DashboardNumber m_coralStatorCurrentLimit = m_coralTuner.tunable(
+      "StatorCurrentLimit", GripperConstants.CoralStatorCurrentLimit.in(Amps), (config, newValue) -> config.CurrentLimits.StatorCurrentLimit = newValue);
+      
 
   /**
    * Creates a new Gripper.
@@ -69,6 +79,13 @@ public class Gripper extends AbstractArmPart {
     m_algaeMotor.Configuration.CurrentLimits.SupplyCurrentLimitEnable = true;
     m_algaeMotor.Configuration.CurrentLimits.SupplyCurrentLimit = m_algaeSupplyCurrentLimit.get();
     m_algaeMotor.applyConfig();
+
+    m_coralMotor.Configuration.CurrentLimits.StatorCurrentLimitEnable = true;
+    m_coralMotor.Configuration.CurrentLimits.StatorCurrentLimit = m_coralStatorCurrentLimit.get();
+    m_coralMotor.Configuration.CurrentLimits.SupplyCurrentLimitEnable = true;
+    m_coralMotor.Configuration.CurrentLimits.SupplyCurrentLimit = m_coralSupplyCurrentLimit.get();
+    m_coralMotor.Configuration.MotorOutput.NeutralMode = NeutralModeValue.Brake;
+    m_coralMotor.applyConfig();
   }
 
   /**


### PR DESCRIPTION
[algae gripper at a low speed/stall to hold onto it](https://github.com/Manchester-Central/2025-Reefscape/commit/734df0ba9f65e87087fff01852bb9914b225bb1f)


[Algae gripper runs when grabbing coral](https://github.com/Manchester-Central/2025-Reefscape/commit/10b638bcf3039af9db76ec2bd51079d6384f7f69)


[Current limit for gripper and coral motors](https://github.com/Manchester-Central/2025-Reefscape/commit/3d558d50d0d1b1df391bf8044c38fdca055bec33)


[Inverted coral and algae motor speed for L4 scoring](https://github.com/Manchester-Central/2025-Reefscape/commit/76ccffda4907856581e25ddd307d0ecbadbfa3dc)