### PR TITLE
UNH Prep - Before Load-in

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -182,7 +182,7 @@ public final class Constants {
       public static final ArmPose ScoreL1 = new ArmPose("ScoreL1", 75.5, 0.28, -75.9);
       public static final ArmPose ScoreL2 = new ArmPose("ScoreL2", 75.0, 0.56, -75.0);
       public static final ArmPose ScoreL3 = new ArmPose("ScoreL3", 80.0, 0.93, -79.0);
-      public static final ArmPose ScoreL4 = new ArmPose("ScoreL4", 75.5, 1.33, 48.0);
+      public static final ArmPose ScoreL4 = new ArmPose("ScoreL4", 75.5, 1.33, 48.0).withBasePivotSafety(85);
 
       // Coral Pickup Poses
       public static final ArmPose HpIntake = new ArmPose("HpIntake", 73, 0.65, -39.0); // Last updated 2/22/25

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -155,11 +155,10 @@ public class RobotContainer extends ChaosRobotContainer<SwerveDrive> {
     m_swerveDrive.setDefaultCommand(new DriverRelativeDrive(m_driver, m_swerveDrive)); 
 
     // Everything after this is for competition
-    // m_driver.a().whileTrue(new DriverRelativeSetAngleDrive(m_driver, m_swerveDrive,  () -> {
-    //   FieldPoint pose = FieldPoint.getNearestPoint(m_swerveDrive.getPose(), FieldPoint.getHpDrivePoses());
-    //   return pose.getCurrentAlliancePose().getRotation();
-    // }, 1.0));
-    m_driver.a().whileTrue(new ChangeState().setArm(ArmState.INTAKE_FROM_HP).withArmInterrupt(ArmState.STOW)); // TODO: re-enable driving
+    m_driver.a().whileTrue(new DriverRelativeSetAngleDrive(m_driver, m_swerveDrive,  () -> {
+      FieldPoint pose = FieldPoint.getNearestPoint(m_swerveDrive.getPose(), FieldPoint.getHpDrivePoses());
+      return pose.getCurrentAlliancePose().getRotation();
+    }, 1.0).alongWith(new ChangeState().setArm(ArmState.INTAKE_FROM_HP).withArmInterrupt(ArmState.STOW)));
     // m_driver.a().whileTrue(PathUtil.driveToClosestPointCommand(FieldPoint.getHpDrivePoses(), m_swerveDrive)
     //     .alongWith(new ChangeState().setArm(ArmState.INTAKE_FROM_HP)
     //     .withArmInterrupt(ArmState.STOW)));
@@ -187,11 +186,12 @@ public class RobotContainer extends ChaosRobotContainer<SwerveDrive> {
                           () -> m_swerveDrive.setRampRatePeriod(SwerveConstants.DriverRampRatePeriod)));
     m_driver.rightBumper().whileTrue(
       new ChangeState().setArm(() -> m_selectedCoralState.PrepState).withArmInterrupt(ArmState.HOLD_CORAL));
+    // Right trigger just causes scoring from the prep states
+    // m_driver.rightTrigger().whileTrue(new ConditionalCommand(
+    //     new ChangeState().setArm(ArmState.SCORE_ALGAE).withArmInterrupt(ArmState.HOLD_ALGAE), 
+    //     new ChangeState().setArm(() -> m_selectedCoralState.ScoreState).withArmInterrupt(ArmState.HOLD_CORAL), 
+    //     m_arm.m_gripper::hasAlgae));
 
-    m_driver.rightTrigger().whileTrue(new ConditionalCommand(
-        new ChangeState().setArm(ArmState.SCORE_ALGAE).withArmInterrupt(ArmState.HOLD_ALGAE), 
-        new ChangeState().setArm(() -> m_selectedCoralState.ScoreState).withArmInterrupt(ArmState.HOLD_CORAL), 
-        m_arm.m_gripper::hasAlgae));
     m_driver.leftTrigger().whileTrue(new ChangeState().setArm(ArmState.INTAKE_CORAL_FROM_FLOOR).withArmInterrupt(ArmState.STOW));
     m_driver.leftBumper().whileTrue(new ChangeState().setArm(() -> {
       var closestTag = FieldPoint.getNearestPoint(m_swerveDrive.getPose(), FieldPoint.getReefAprilTagPoses());
@@ -214,19 +214,8 @@ public class RobotContainer extends ChaosRobotContainer<SwerveDrive> {
     
     m_operator.start().onTrue(new ChangeState().setArm(ArmState.STOW));
     m_operator.back().whileTrue(new ChangeState().setArm(ArmState.MANUAL));
-    //.alongWith(new InstantCommand(() -> m_arm.m_gripperPivot.disableFuseCANcoder()))
 
     // Everything after this is for demos and testing
-
-    // m_driver.rightBumper().whileTrue(new ChangeState().setArm(ArmState.PREP_PROCESSOR));
-    // m_driver.rightTrigger().whileTrue(new ChangeState().setArm(ArmState.PREP_BARGE));
-
-    // m_driver.a().whileTrue(new SimpleDriveToPosition(m_swerveDrive, FieldPoint.leftSource));
-    // m_driver.b().whileTrue(m_swerveDrive.followPathCommand("Test Path"));
-    // m_driver.y().whileTrue(PathUtil.driveToClosestPointCommand(FieldPoint.getHpDrivePoses(), m_swerveDrive));
-    // m_driver.x().whileTrue(PathUtil.driveToClosestPointCommand(FieldPoint.getReefDrivePoses(), m_swerveDrive));
-
-
 
     // v on keyboard 0
     m_simKeyboard.y().onTrue(
@@ -247,27 +236,6 @@ public class RobotContainer extends ChaosRobotContainer<SwerveDrive> {
     );
     // z on keyboard 0
     m_simKeyboard.a().onTrue(new InstantCommand(() -> Gripper.hasCoralGrippedSim = !Gripper.hasCoralGrippedSim));
-
-    // m_operator.start().whileTrue(new ChangeState().setArm(ArmState.STOW).setIntake(IntakeState.STOW));
-    // m_operator.leftBumper().whileTrue(new ChangeState().setArm(ArmState.INTAKE_FROM_FLOOR).setIntake(IntakeState.DEPLOY));
-    // m_operator.rightBumper().whileTrue(new ChangeState().setArm(ArmState.INTAKE_FROM_HP).setIntake(IntakeState.STOW));
-    // m_operator.back().onTrue(new InstantCommand(() -> Gripper.hasCoralGrippedSim = !Gripper.hasCoralGrippedSim)); // TODO: delete if back button needed for competition
-    // m_operator.povLeft().whileTrue(new ChangeState().setArm(ArmState.MANUAL).setIntake(IntakeState.STOW));
-
-    // m_operator.leftTrigger().whileTrue(new RunCommand(() -> m_arm.m_gripperPivot.setTargetAngle(Rotation2d.fromDegrees(-20)),
-    //     m_arm));
-    // m_operator.rightTrigger().whileTrue(new RunCommand(() -> m_arm.m_gripperPivot.setTargetAngle(Rotation2d.fromDegrees(-90)),
-    //     m_arm));
-    // m_operator.a().whileTrue(new RunCommand(() -> m_arm.m_extender.setTargetLength(0.5), m_arm));
-    // m_operator.b().whileTrue(new RunCommand(() -> m_arm.m_extender.setTargetLength(1.2), m_arm));
-    // m_operator.a().whileTrue(new RunCommand(() -> {
-    //   m_arm.m_basePivot.setTargetAngle(ArmPoses.HpIntake.getBasePivotAngle());
-    //   double yValue = -0.5;
-    //   if (m_arm.m_gripper.hasCoral()) {
-    //     yValue = yValue < 0 ? 0 : yValue;
-    //   }
-    //   m_arm.m_gripper.setCoralGripSpeed(yValue);
-    // }, m_arm));
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/arm/Arm.java
+++ b/src/main/java/frc/robot/subsystems/arm/Arm.java
@@ -205,17 +205,17 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
 */
     m_basePivot.setSpeed(m_operator.getRightY() * 0.131);
 
-    m_extender.setSpeed(m_operator.getLeftY() * 0.5);
+    // m_extender.setSpeed(m_operator.getLeftY() * 0.5);
 
-    // m_gripperPivot.setSpeed(m_operator.getLeftY() * 0.2);
+     m_gripperPivot.setSpeed(m_operator.getLeftY() * 0.2);
 
-    if (m_operator.leftBumper().getAsBoolean()) {
-      m_gripperPivot.setSpeed(0.2);
-    } else if (m_operator.leftTrigger().getAsBoolean()) {
-      m_gripperPivot.setSpeed(-0.2);
-    } else {
-      m_gripperPivot.setSpeed(0);
-    }
+    // if (m_operator.leftBumper().getAsBoolean()) {
+    //   m_gripperPivot.setSpeed(0.2);
+    // } else if (m_operator.leftTrigger().getAsBoolean()) {
+    //   m_gripperPivot.setSpeed(-0.2);
+    // } else {
+    //   m_gripperPivot.setSpeed(0);
+    // }
 
     if (m_operator.rightBumper().getAsBoolean()) {
       m_gripper.setCoralGripSpeed(0.2);
@@ -432,7 +432,10 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
       changeState(ArmState.STOW);
       return;
     }
-    m_basePivot.setTargetAngle(armPose.getBasePivotAngle());
+    Rotation2d targetBasePivotAngle = armPose.getBasePivotSafetyAngle().isPresent() && (!m_gripperPivot.atTarget() || !m_extender.atTarget()) 
+          ? armPose.getBasePivotSafetyAngle().get() 
+          : armPose.getBasePivotAngle();
+    m_basePivot.setTargetAngle(targetBasePivotAngle);
     m_extender.setTargetLength(armPose.getExtensionMeters());
     m_gripperPivot.setTargetAngle(armPose.getGripperPivotAngle());
     if ((!isPrep && isPoseReady()) || m_operator.rightBumper().getAsBoolean() || (DriverStation.isAutonomousEnabled() && isPoseClose() && m_stateTimer.hasElapsed(2))) {

--- a/src/main/java/frc/robot/subsystems/arm/Arm.java
+++ b/src/main/java/frc/robot/subsystems/arm/Arm.java
@@ -202,17 +202,17 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
 */
     m_basePivot.setSpeed(m_operator.getRightY() * 0.131);
 
-    // m_extender.setSpeed(m_operator.getLeftY() * 0.5);
+    m_extender.setSpeed(m_operator.getLeftY() * 0.5);
 
-     m_gripperPivot.setSpeed(m_operator.getLeftY() * 0.2);
+    // m_gripperPivot.setSpeed(m_operator.getLeftY() * 0.2);
 
-    // if (m_operator.leftBumper().getAsBoolean()) {
-    //   m_gripperPivot.setSpeed(0.2);
-    // } else if (m_operator.leftTrigger().getAsBoolean()) {
-    //   m_gripperPivot.setSpeed(-0.2);
-    // } else {
-    //   m_gripperPivot.setSpeed(0);
-    // }
+    if (m_operator.leftBumper().getAsBoolean()) {
+      m_gripperPivot.setSpeed(0.2);
+    } else if (m_operator.leftTrigger().getAsBoolean()) {
+      m_gripperPivot.setSpeed(-0.2);
+    } else {
+      m_gripperPivot.setSpeed(0);
+    }
 
     if (m_operator.rightBumper().getAsBoolean()) {
       m_gripper.setCoralGripSpeed(0.2);

--- a/src/main/java/frc/robot/subsystems/arm/Arm.java
+++ b/src/main/java/frc/robot/subsystems/arm/Arm.java
@@ -105,7 +105,7 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
   }
 
   @Override
-  protected void runStateMachine() {
+  protected void runStateMachine(boolean isFirstRun) {
     switch (getCurrentState()) {
       case MANUAL:
         manualState();

--- a/src/main/java/frc/robot/subsystems/arm/Arm.java
+++ b/src/main/java/frc/robot/subsystems/arm/Arm.java
@@ -59,6 +59,7 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
   public GripperPivot m_gripperPivot = new GripperPivot(this::getArmValues);
   private Gamepad m_operator;
   private Gamepad m_driver;
+  private boolean m_isPrepAngleReached = false;
 
   /**
    * The possible states of the Arm's state machine.
@@ -82,7 +83,6 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
     SCORE_L4,
     ALGAE_HIGH,
     ALGAE_LOW,
-    SCORE_ALGAE,
     HOLD_CORAL,
     HOLD_ALGAE,
     PREP_CLIMB,
@@ -105,7 +105,7 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
   }
 
   @Override
-  protected void runStateMachine(boolean isFirstRun) {
+  protected void runStateMachine() {
     switch (getCurrentState()) {
       case MANUAL:
         manualState();
@@ -155,9 +155,6 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
         break;
       case SCORE_L4:
         scoreL4State();
-        break;
-      case SCORE_ALGAE:
-        scoreAlgaeState();
         break;
       case ALGAE_HIGH:
         algaeHighState();
@@ -344,6 +341,9 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
     m_gripperPivot.setTargetAngle(ArmPoses.ScoreProcessor.getGripperPivotAngle());
     m_gripper.setAlgaeGripSpeed(GripperConstants.HoldAlgaeSpeed);
     m_gripper.setCoralGripSpeed(0.0);
+    if (m_driver.rightTrigger().getAsBoolean()) {
+      scoreAlgaeHelper();
+    }
   }
 
   private void prepBargeState() {
@@ -352,6 +352,9 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
     m_gripperPivot.setTargetAngle(ArmPoses.ScoreBarge.getGripperPivotAngle());
     m_gripper.setAlgaeGripSpeed(GripperConstants.HoldAlgaeSpeed);
     m_gripper.setCoralGripSpeed(0.0);
+    if (m_driver.rightTrigger().getAsBoolean()) {
+      scoreAlgaeHelper();
+    }
   }
 
   private void scoreL1State() {
@@ -368,14 +371,6 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
 
   private void scoreL4State() {
     scoreHelperCoral(ArmPoses.ScoreL4, false, true);
-  }
-
-  private void scoreAlgaeState() {
-    m_gripper.setAlgaeGripSpeed(GripperConstants.OutakeAlgaeSpeed);
-    m_gripper.setCoralGripSpeed(0.0);
-    if (Robot.isSimulation() && getElapsedStateSeconds() > 2.0) {
-      Gripper.hasAlgaeGrippedSim = false;
-    }
   }
 
   private void algaeHighState() {
@@ -432,22 +427,45 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
       changeState(ArmState.STOW);
       return;
     }
-    Rotation2d targetBasePivotAngle = armPose.getBasePivotSafetyAngle().isPresent() && (!m_gripperPivot.atTarget() || !m_extender.atTarget()) 
-          ? armPose.getBasePivotSafetyAngle().get() 
-          : armPose.getBasePivotAngle();
-    m_basePivot.setTargetAngle(targetBasePivotAngle);
+
+    boolean usePrepAngle = armPose.getBasePivotSafetyAngle().isPresent();
+    if (usePrepAngle && isStateStarting()) {
+      // If this is the first time the state has run, reset the angle reached variable
+      m_isPrepAngleReached = false;
+    }
+
+    // If we have a prep base pivot angle, make sure we go there first
+    if (usePrepAngle && !m_isPrepAngleReached) {
+      m_basePivot.setTargetAngle(armPose.getBasePivotSafetyAngle().get());
+      m_extender.setTargetLength(armPose.getExtensionMeters());
+      m_gripperPivot.setTargetAngle(armPose.getGripperPivotAngle());
+      m_isPrepAngleReached = isPoseClose();
+      return;
+    }
+
+    m_basePivot.setTargetAngle(armPose.getBasePivotAngle());
     m_extender.setTargetLength(armPose.getExtensionMeters());
     m_gripperPivot.setTargetAngle(armPose.getGripperPivotAngle());
-    if ((!isPrep && isPoseReady()) || m_operator.rightBumper().getAsBoolean() || (DriverStation.isAutonomousEnabled() && isPoseClose() && m_stateTimer.hasElapsed(2))) {
+
+    boolean isControllerScoring = m_driver.rightTrigger().getAsBoolean() || m_operator.rightBumper().getAsBoolean();
+    boolean isAutonomousScoringTimedOut = DriverStation.isAutonomousEnabled() && isPoseClose() && m_stateTimer.hasElapsed(2);
+    if ((!isPrep && isPoseReady()) || isControllerScoring || isAutonomousScoringTimedOut) {
       m_gripper.setCoralGripSpeed(isScoringInverted ? GripperConstants.OutakeInvertedCoralSpeed : GripperConstants.OutakeCoralSpeed);
       m_gripper.setAlgaeGripSpeed(isScoringInverted ? GripperConstants.OutakeInvertedCoralOnAlgaeMotorSpeed : GripperConstants.OutakeCoralOnAlgaeMotorSpeed);
+      if (Robot.isSimulation() && getElapsedStateSeconds() > 2.0) {
+        Gripper.hasCoralGrippedSim = false;
+      }
     } else {
       m_gripper.setCoralGripSpeed(0);
       m_gripper.setAlgaeGripSpeed(0.0);
     }
+  }
 
-    if (!isPrep && Robot.isSimulation() && getElapsedStateSeconds() > 2.0) {
-      Gripper.hasCoralGrippedSim = false;
+  private void scoreAlgaeHelper() {
+    m_gripper.setAlgaeGripSpeed(GripperConstants.OutakeAlgaeSpeed);
+    m_gripper.setCoralGripSpeed(0.0);
+    if (Robot.isSimulation() && getElapsedStateSeconds() > 2.0) {
+      Gripper.hasAlgaeGrippedSim = false;
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/arm/ArmPose.java
+++ b/src/main/java/frc/robot/subsystems/arm/ArmPose.java
@@ -4,6 +4,8 @@
 
 package frc.robot.subsystems.arm;
 
+import java.util.Optional;
+
 import com.chaos131.util.DashboardNumber;
 import edu.wpi.first.math.geometry.Rotation2d;
 
@@ -13,6 +15,7 @@ public class ArmPose {
   private Rotation2d m_basePivotAngle;
   private double m_extensionMeters;
   private Rotation2d m_gripperPivotAngle;
+  private Optional<Rotation2d> m_basePivotSafetyAngle = Optional.empty();
 
   /** Creates a new arm pose. */
   public ArmPose(String name, double basePivotDegrees, double extensionMeters, double gripperPivotDegrees) {
@@ -37,6 +40,23 @@ public class ArmPose {
     );
   }
 
+  /**
+   * add an angle that the base pivot will go to before the proper target.
+   */
+  public ArmPose withBasePivotSafety(Rotation2d safetyRotation) {
+    m_basePivotSafetyAngle = Optional.of(safetyRotation);
+    return this;
+  }
+  
+  /**
+   * add an angle that the base pivot will go to before the proper target.
+   */
+  public ArmPose withBasePivotSafety(double safetyRotation) {
+    return withBasePivotSafety(Rotation2d.fromDegrees(safetyRotation));
+  }
+
+
+
   public Rotation2d getBasePivotAngle() {
     return m_basePivotAngle;
   }
@@ -47,5 +67,9 @@ public class ArmPose {
 
   public Rotation2d getGripperPivotAngle() {
     return m_gripperPivotAngle;
+  }
+
+  public Optional<Rotation2d> getBasePivotSafetyAngle() {
+    return m_basePivotSafetyAngle;
   }
 }

--- a/src/main/java/frc/robot/subsystems/shared/StateBasedSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shared/StateBasedSubsystem.java
@@ -12,6 +12,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 public abstract class StateBasedSubsystem<T extends SubsystemState> extends SubsystemBase {
   private T m_currentState;
   protected Timer m_stateTimer = new Timer();
+  private boolean m_isStateFirstRun = true;
 
   /**
    * The base contrusctor for all state based subsystems.
@@ -21,13 +22,16 @@ public abstract class StateBasedSubsystem<T extends SubsystemState> extends Subs
   protected StateBasedSubsystem(T startState) {
     m_currentState = startState;
     m_stateTimer.start();
-    this.setDefaultCommand(new RunCommand(() -> runStateMachine(), this));
+    this.setDefaultCommand(new RunCommand(() -> {
+      runStateMachine(m_isStateFirstRun);
+      m_isStateFirstRun = false;
+    }, this));
   }
 
   /**
    * The function that must be called every loop to run the state machine.
    */
-  protected abstract void runStateMachine();
+  protected abstract void runStateMachine(boolean isFirstRun);
 
   /**
    * Changes the current state of the state machine.
@@ -37,6 +41,7 @@ public abstract class StateBasedSubsystem<T extends SubsystemState> extends Subs
   public void changeState(T newState) {
     if (newState != m_currentState) {
       m_stateTimer.restart();
+      m_isStateFirstRun = true;
     }
 
     m_currentState = newState;

--- a/src/main/java/frc/robot/subsystems/shared/StateBasedSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shared/StateBasedSubsystem.java
@@ -12,7 +12,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 public abstract class StateBasedSubsystem<T extends SubsystemState> extends SubsystemBase {
   private T m_currentState;
   protected Timer m_stateTimer = new Timer();
-  private boolean m_isStateFirstRun = true;
+  private boolean m_isStateStarting = true;
 
   /**
    * The base contrusctor for all state based subsystems.
@@ -23,15 +23,15 @@ public abstract class StateBasedSubsystem<T extends SubsystemState> extends Subs
     m_currentState = startState;
     m_stateTimer.start();
     this.setDefaultCommand(new RunCommand(() -> {
-      runStateMachine(m_isStateFirstRun);
-      m_isStateFirstRun = false;
+      runStateMachine();
+      m_isStateStarting = false;
     }, this));
   }
 
   /**
    * The function that must be called every loop to run the state machine.
    */
-  protected abstract void runStateMachine(boolean isFirstRun);
+  protected abstract void runStateMachine();
 
   /**
    * Changes the current state of the state machine.
@@ -41,7 +41,7 @@ public abstract class StateBasedSubsystem<T extends SubsystemState> extends Subs
   public void changeState(T newState) {
     if (newState != m_currentState) {
       m_stateTimer.restart();
-      m_isStateFirstRun = true;
+      m_isStateStarting = true;
     }
 
     m_currentState = newState;
@@ -55,4 +55,7 @@ public abstract class StateBasedSubsystem<T extends SubsystemState> extends Subs
     return m_stateTimer.get();
   }
 
+  public boolean isStateStarting() {
+    return m_isStateStarting;
+  }
 }


### PR DESCRIPTION
* Finishes the logic @NinjaBuilderPro and I were working on for protecting the L4 score
* Adds a separate algae mode trigger - operator LB/LT selects the processor/barge (respectively) and holding either allows the driver to perform algae actions
  * A color for the mode can be shown on the dashboard
* Changes driver RT to score from the prep states (doesn't change a state itself)
* Other cleanup

Updated the controller document here:
https://docs.google.com/presentation/d/1BxvOi_abQ2YRpMpBu-wXGIzi-XrgvOg9U3S-nEigRFw/edit?usp=sharing
  
