### PR TITLE
Adds NamedCommands for every reef pole and score position

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    implementation 'com.chaos131:shared:2025.0.13.beta-14163570745'
+    implementation 'com.chaos131:shared:2025.0.13'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    implementation 'com.chaos131:shared:2025.0.12'
+    implementation 'com.chaos131:shared:2025.0.13.beta-14163570745'
 }
 
 test {

--- a/src/main/deploy/pathplanner/autos/FullyAutoTest.auto
+++ b/src/main/deploy/pathplanner/autos/FullyAutoTest.auto
@@ -1,0 +1,67 @@
+{
+  "version": "2025.0",
+  "command": {
+    "type": "sequential",
+    "data": {
+      "commands": [
+        {
+          "type": "path",
+          "data": {
+            "pathName": "Right3-2L"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "AimReef-2L-L4"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "ScoreL4"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "AimHP"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "AimReef-6R-L2"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "ScoreL2"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "AimHP"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "AimReef-6L-L4"
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "ScoreL4"
+          }
+        }
+      ]
+    }
+  },
+  "resetOdom": true,
+  "folder": "Test",
+  "choreoAuto": false
+}

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -19,6 +19,7 @@ import edu.wpi.first.net.WebServer;
 import edu.wpi.first.wpilibj.Filesystem;
 import frc.robot.Constants.GeneralConstants;
 import frc.robot.Constants.SwerveConstants;
+import frc.robot.subsystems.SwerveDrive;
 import frc.robot.subsystems.arm.Gripper;
 import frc.robot.utils.FieldPoint;
 import frc.robot.utils.LocalADStarAK;
@@ -33,7 +34,7 @@ import org.littletonrobotics.junction.Logger;
  * the TimedRobot documentation. If you change the name of this class or the package after creating
  * this project, you must also update the Main.java file in the project.
  */
-public class Robot extends ChaosRobot {
+public class Robot extends ChaosRobot<SwerveDrive, RobotContainer> {
 
   public String m_autoName = "";
   public String m_newAutoName = "";
@@ -80,7 +81,7 @@ public class Robot extends ChaosRobot {
   public void robotPeriodic() {
     super.robotPeriodic();
     DashboardNumber.checkAll();
-    ((RobotContainer) m_robotContainer).setSwerveDriveAcceptingVisionUpdates(isDisabled() ? true : SwerveConstants.AcceptVisionUpdates);
+    m_robotContainer.setSwerveDriveAcceptingVisionUpdates(isDisabled() ? true : SwerveConstants.AcceptVisionUpdates);
   }
 
   @Override
@@ -88,27 +89,27 @@ public class Robot extends ChaosRobot {
     Pathfinding.setPathfinder(new LocalADStarAK());
     PathfindingCommand.warmupCommand().schedule();
     Gripper.hasCoralGrippedSim = true;
-    ((RobotContainer) m_robotContainer).setMotorCleanUp();
+    m_robotContainer.setMotorCleanUp();
     super.robotInit(); 
     WebServer.start(5800, Filesystem.getDeployDirectory().getPath());
   }
 
   @Override
   public void disabledCleanup() {
-    ((RobotContainer) m_robotContainer).setMotorCleanUp();
+    m_robotContainer.setMotorCleanUp();
   }
 
   @Override
   public void teleopInit() {
-    ((RobotContainer) m_robotContainer).setMotorStartUp();
-    ((RobotContainer) m_robotContainer).autoAndTeleInit();
+    m_robotContainer.setMotorStartUp();
+    m_robotContainer.autoAndTeleInit();
     super.teleopInit();
   }
 
   @Override
   public void autonomousInit() {
-    ((RobotContainer) m_robotContainer).setMotorStartUp();
-    ((RobotContainer) m_robotContainer).autoAndTeleInit();
+    m_robotContainer.setMotorStartUp();
+    m_robotContainer.autoAndTeleInit();
     Gripper.hasCoralGrippedSim = true;
     super.autonomousInit();
   }
@@ -133,15 +134,11 @@ public class Robot extends ChaosRobot {
         for (PathPlannerPath path : pathPlannerPaths) {
           poses.addAll(path.getAllPathPoints().stream().map(point -> new Pose2d(point.position.getX(), point.position.getY(), new Rotation2d())).collect(Collectors.toList()));
         }
-        getRobotContainer().getField().getObject("path").setPoses(poses);
+        m_robotContainer.getField().getObject("path").setPoses(poses);
       } else {
-        getRobotContainer().getField().getObject("path").setPoses(new ArrayList<>());
+        m_robotContainer.getField().getObject("path").setPoses(new ArrayList<>());
       }
     }
 
-  }
-
-  public RobotContainer getRobotContainer() {
-    return (RobotContainer) m_robotContainer;
   }
 }

--- a/src/main/java/frc/robot/subsystems/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/SwerveDrive.java
@@ -5,6 +5,7 @@
 package frc.robot.subsystems;
 
 import static edu.wpi.first.units.Units.Degrees;
+import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 
 import com.chaos131.robot.ChaosRobot.Mode;
@@ -38,6 +39,7 @@ import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import frc.robot.Constants.CanIdentifiers;
+import frc.robot.Constants.FieldDimensions;
 import frc.robot.Constants.GeneralConstants;
 import frc.robot.Constants.SwerveConstants;
 import frc.robot.Constants.SwerveConstants.SwerveBackLeftConstants;
@@ -45,6 +47,7 @@ import frc.robot.Constants.SwerveConstants.SwerveBackRightConstants;
 import frc.robot.Constants.SwerveConstants.SwerveFrontLeftConstants;
 import frc.robot.Constants.SwerveConstants.SwerveFrontRightConstants;
 import frc.robot.Robot;
+import frc.robot.utils.FieldPoint;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.ironmaple.simulation.SimulatedArena;
@@ -351,6 +354,9 @@ public class SwerveDrive extends BaseSwerveDrive {
     Rotation2d currentAngle = getPose().getTranslation().minus(targetPosition).getAngle();
     Logger.recordOutput("at target dynamic", atTargetDynamic());
     Logger.recordOutput("Command", getCurrentCommand() != null ? getCurrentCommand().getName() : "");
+
+    Logger.recordOutput("ReefScoringDistanceThresholdIsMet", FieldPoint.ReefCenter.getDistance(getPose()).lte(FieldDimensions.ReefScoringDistanceThreshold));
+    Logger.recordOutput("ReefCenterDistanceMeters", FieldPoint.ReefCenter.getDistance(getPose()));
     m_swerveAngles.addLast(currentAngle);
   }
 

--- a/src/main/java/frc/robot/subsystems/arm/Arm.java
+++ b/src/main/java/frc/robot/subsystems/arm/Arm.java
@@ -495,7 +495,7 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
       m_basePivot.setTargetAngle(armPose.getBasePivotSafetyAngle().get());
       m_extender.setTargetLength(armPose.getExtensionMeters());
       m_gripperPivot.setTargetAngle(armPose.getGripperPivotAngle());
-      m_isPrepAngleReached = isPoseClose();
+      m_isPrepAngleReached = isPoseClose() || (Robot.isSimulation() && getElapsedStateSeconds() > 1.0);
       return;
     }
 
@@ -555,7 +555,7 @@ public class Arm extends StateBasedSubsystem<Arm.ArmState> {
       m_basePivot.setTargetAngle(ArmPoses.ScoreL4.getBasePivotSafetyAngle().get());
       m_extender.setTargetLength(ArmPoses.ScoreL4.getExtensionMeters());
       m_gripperPivot.setTargetAngle(ArmPoses.ScoreL4.getGripperPivotAngle());
-      if (getArmValues().isBasePivotAtCloseAngle) {
+      if (getArmValues().isBasePivotAtCloseAngle || (Robot.isSimulation() && getElapsedStateSeconds() > 1.0)) {
         changeState(ArmState.STOW);
       }
     } else {

--- a/src/main/java/frc/robot/utils/FieldPoint.java
+++ b/src/main/java/frc/robot/utils/FieldPoint.java
@@ -129,11 +129,11 @@ public class FieldPoint {
     return reefDrivePoses;
   }
 
-  private static FieldPoint getDrivePoseFromReefFace(Pose2d aprilTagPose, boolean isLeft) {
+  private static FieldPoint getDrivePoseFromReefFace(Pose2d aprilTagPose, boolean isRight) {
     Pose2d pose = aprilTagPose.transformBy(
         new Transform2d(
             RobotDimensions.FrontBackLength.in(Meters) / 2 + RobotDimensions.RobotToReefMargin,
-            isLeft ? FieldDimensions.ReefBranchLeft.getY() : FieldDimensions.ReefBranchRight.getY(),
+            isRight ? FieldDimensions.ReefBranchRight.getY() : FieldDimensions.ReefBranchLeft.getY(),
             Rotation2d.fromDegrees(180)));
     return new FieldPoint("ReefDrivePose", pose);
   }
@@ -145,9 +145,9 @@ public class FieldPoint {
   public static Pose2d getNearestReefDrivePose(SwerveDrive swerveDrive, double stickBias) {
     ArrayList<FieldPoint> reefDrivePoses = new ArrayList<FieldPoint>();
     FieldPoint aprilTag = getNearestPoint(swerveDrive.getPose(), getReefAprilTagPoses());
-    FieldPoint leftPose = getDrivePoseFromReefFace(aprilTag.getBluePose(), true);
+    FieldPoint leftPose = getDrivePoseFromReefFace(aprilTag.getBluePose(), false);
     reefDrivePoses.add(leftPose);
-    FieldPoint rightPose = getDrivePoseFromReefFace(aprilTag.getBluePose(), false);
+    FieldPoint rightPose = getDrivePoseFromReefFace(aprilTag.getBluePose(), true);
     reefDrivePoses.add(rightPose);
     if (stickBias < -0.1) {
       return aprilTag.m_bluePose.getRotation().getMeasure().isNear(Degrees.of(180), Degrees.of(90)) ? leftPose.getCurrentAlliancePose() : rightPose.getCurrentAlliancePose();

--- a/src/main/java/frc/robot/utils/FieldPoint.java
+++ b/src/main/java/frc/robot/utils/FieldPoint.java
@@ -77,20 +77,19 @@ public class FieldPoint {
     return new FieldPoint(newName, new Pose2d(x, y, Rotation2d.kZero));
   }
 
-  // TODO: evaluate L/R matches driver's perspective
   public static Map<String, FieldPoint> ReefClockPoses = Map.ofEntries(
-      Map.entry("2L", getDrivePoseFromReefFace(ReefPose2.getBluePose(), false)),
-      Map.entry("2R", getDrivePoseFromReefFace(ReefPose2.getBluePose(), true)),
+      Map.entry("2L", getDrivePoseFromReefFace(ReefPose2.getBluePose(), true)),
+      Map.entry("2R", getDrivePoseFromReefFace(ReefPose2.getBluePose(), false)),
       Map.entry("4L", getDrivePoseFromReefFace(ReefPose4.getBluePose(), false)),
       Map.entry("4R", getDrivePoseFromReefFace(ReefPose4.getBluePose(), true)),
       Map.entry("6L", getDrivePoseFromReefFace(ReefPose6.getBluePose(), false)),
       Map.entry("6R", getDrivePoseFromReefFace(ReefPose6.getBluePose(), true)),
       Map.entry("8L", getDrivePoseFromReefFace(ReefPose8.getBluePose(), false)),
       Map.entry("8R", getDrivePoseFromReefFace(ReefPose8.getBluePose(), true)),
-      Map.entry("10L", getDrivePoseFromReefFace(ReefPose10.getBluePose(), false)),
-      Map.entry("10R", getDrivePoseFromReefFace(ReefPose10.getBluePose(), true)),
-      Map.entry("12L", getDrivePoseFromReefFace(ReefPose12.getBluePose(), false)),
-      Map.entry("12R", getDrivePoseFromReefFace(ReefPose12.getBluePose(), true))
+      Map.entry("10L", getDrivePoseFromReefFace(ReefPose10.getBluePose(), true)),
+      Map.entry("10R", getDrivePoseFromReefFace(ReefPose10.getBluePose(), false)),
+      Map.entry("12L", getDrivePoseFromReefFace(ReefPose12.getBluePose(), true)),
+      Map.entry("12R", getDrivePoseFromReefFace(ReefPose12.getBluePose(), false))
   );
 
   /**

--- a/src/main/java/frc/robot/utils/PathUtil.java
+++ b/src/main/java/frc/robot/utils/PathUtil.java
@@ -70,12 +70,23 @@ public class PathUtil {
           }
           FieldPoint nearestPoint = FieldPoint.getNearestPoint(swerveDrive.getPose(), possibleTargets);
           Logger.recordOutput("Swerve/Nearest Point", nearestPoint.getCurrentAlliancePose());
-          Command simpleDriveToPosition = new SimpleDriveToPositionV2(swerveDrive, nearestPoint);
-          if (DriverStation.isAutonomousEnabled()) {
-            simpleDriveToPosition = simpleDriveToPosition.withTimeout(timeOutSeconds);
-          }
+          Command simpleDriveToPosition = new SimpleDriveToPositionV2(swerveDrive, nearestPoint).withTimeout(timeOutSeconds);
           return AutoBuilder.pathfindToPose(
               swerveDrive.getPose().nearest(possiblePoses), constraints, 0.0).andThen(simpleDriveToPosition);
+        },
+        Set.of(swerveDrive));
+  }
+
+  /**
+   * Drives to the target FieldPoint on the field (respective of the current alliance).
+   */
+  public static Command driveToClosestPointAutoCommand(FieldPoint target, SwerveDrive swerveDrive, double timeOutSeconds) {
+    return new DeferredCommand(
+        () -> {
+          Logger.recordOutput("Swerve/Nearest Point", target.getCurrentAlliancePose());
+          Command simpleDriveToPosition = new SimpleDriveToPositionV2(swerveDrive, target).withTimeout(timeOutSeconds);
+          return AutoBuilder.pathfindToPose(
+            target.getCurrentAlliancePose(), constraints, 0.0).andThen(simpleDriveToPosition);
         },
         Set.of(swerveDrive));
   }


### PR DESCRIPTION
This adds NamedCommands to aim at each reef pole and have a prep pose for every one. 

Such as:
-     AimReef-2R
-     AimReef-10L-L4
-     AimReef-6R-L1

I think I didn't do the right clock convention with correct R + L names.
I did right and left while looking at the face, but I think we want to do right and left from the drivers perspective.

An auto that scores three coral with only one path (a start path is needed to set the initial pose)

![image](https://github.com/user-attachments/assets/9947e067-e319-47eb-a4f3-90f448feee26)
